### PR TITLE
Allow with_tail return type

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -79,7 +79,7 @@ encode(Source, Config) -> jsx_to_json:to_json(Source, Config).
 
 decode(Source) -> decode(Source, []).
 
--spec decode(Source::json_text(), Config::jsx_to_term:config()) -> json_term() | {incomplete, decoder()}.
+-spec decode(Source::json_text(), Config::jsx_to_term:config()) -> json_term() | {incomplete, decoder()} | {with_tail, json_term(), binary()}.
 
 decode(Source, Config) -> jsx_to_term:to_term(Source, Config).
 

--- a/src/jsx_decoder.erl
+++ b/src/jsx_decoder.erl
@@ -1169,7 +1169,7 @@ special_number_test_() ->
     Cases = [
         % {title, test form, json, opt flags}
         {"-0", [{integer, 0}, end_json], <<"-0">>},
-        {"-0.0", [{float, 0.0}, end_json], <<"-0.0">>},
+        {"-0.0", [{float, -0.0}, end_json], <<"-0.0">>},
         {"0e0", [{float, 0.0}, end_json], <<"0e0">>},
         {"0e4", [{float, 0.0}, end_json], <<"0e4">>},
         {"1e0", [{float, 1.0}, end_json], <<"1e0">>},

--- a/src/jsx_to_term.erl
+++ b/src/jsx_to_term.erl
@@ -68,7 +68,7 @@
 -endif.
 
 
--spec to_term(Source::binary(), Config::config()) -> json_value().
+-spec to_term(Source::binary(), Config::config()) -> json_value() | {with_tail, json_value(), binary()}.
 
 -ifdef(maps_always).
 to_term(Source, Config) when is_list(Config) ->


### PR DESCRIPTION
For streaming messages through gunpool, I'm using a feature of jsx called `[return_tail]` that returns `{with_tail, Object, Tail}` which allows you to iterate over an incomplete binary stream of ndjson and emit the objects as you go. 

Only problem is that the type spec doesn't have this return type.

Also fixed an issue with the unit tests on OTP >=27